### PR TITLE
Fixed geometrystream reader and writer absolutepath exception

### DIFF
--- a/AEGIS.IO/GeometryStreamReader.cs
+++ b/AEGIS.IO/GeometryStreamReader.cs
@@ -664,7 +664,7 @@ namespace ELTE.AEGIS.IO
             try
             {
                 if (path.IsAbsoluteUri)
-                    return FileSystem.GetFileSystemForPath(path).OpenFile(path.AbsolutePath, FileMode.Open, FileAccess.Read);
+                    return FileSystem.GetFileSystemForPath(path).OpenFile(Uri.UnescapeDataString(path.AbsolutePath), FileMode.Open, FileAccess.Read);
                 else
                     return FileSystem.GetFileSystemForPath(path).OpenFile(path.OriginalString, FileMode.Open, FileAccess.Read);
             }

--- a/AEGIS.IO/GeometryStreamWriter.cs
+++ b/AEGIS.IO/GeometryStreamWriter.cs
@@ -576,7 +576,7 @@ namespace ELTE.AEGIS.IO
             {
                 // open the stream for reading
                 if (path.IsAbsoluteUri)
-                    return FileSystem.GetFileSystemForPath(path).OpenFile(path.AbsolutePath, FileMode.Create, FileAccess.Write);
+                    return FileSystem.GetFileSystemForPath(path).OpenFile(Uri.UnescapeDataString(path.AbsolutePath), FileMode.Create, FileAccess.Write);
                 else
                     return FileSystem.GetFileSystemForPath(path).OpenFile(path.OriginalString, FileMode.Create, FileAccess.Write);
             }


### PR DESCRIPTION
Previously there was an issue, when you wanted to load a file that contained special characters (like space) then a DirectoryNotFoundException was thrown, because the Uri.AbsolutePath stores an encoded path. (instead of a space for example it contained "%20")